### PR TITLE
[POEM-7] fix: 시 생성 시, 빈 문자열 예외처리

### DIFF
--- a/subprojects/api/build.gradle
+++ b/subprojects/api/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'

--- a/subprojects/api/build.gradle
+++ b/subprojects/api/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -11,7 +12,6 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'

--- a/subprojects/api/src/main/java/com/poemfoot/api/controller/CardController.java
+++ b/subprojects/api/src/main/java/com/poemfoot/api/controller/CardController.java
@@ -10,6 +10,7 @@ import com.poemfoot.api.dto.response.card.CardResponse;
 import com.poemfoot.api.service.CardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -56,7 +57,7 @@ public class CardController {
     @PostMapping("/poem")
     @Operation(summary = "시 생성")
     public ResponseEntity<CardPoemResponse> requestPoem(
-            @RequestBody CardPoemRequest request
+            @Valid @RequestBody CardPoemRequest request
     ){
         return ResponseEntity.ok(cardService.getPoem(request.location(), request.address(),
                 request.latitude(), request.longitude()));

--- a/subprojects/api/src/main/java/com/poemfoot/api/dto/request/CardPoemRequest.java
+++ b/subprojects/api/src/main/java/com/poemfoot/api/dto/request/CardPoemRequest.java
@@ -1,7 +1,11 @@
 package com.poemfoot.api.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record CardPoemRequest(
+        @NotBlank(message = "위치 단어는 공백일 수 없습니다.")
         String location,
+        @NotBlank(message = "현재 위치는 공백일 수 없습니다.")
         String address,
         double latitude,
         double longitude

--- a/subprojects/api/src/main/java/com/poemfoot/api/dto/request/MemberRequest.java
+++ b/subprojects/api/src/main/java/com/poemfoot/api/dto/request/MemberRequest.java
@@ -1,7 +1,5 @@
 package com.poemfoot.api.dto.request;
 
-import com.poemfoot.api.domain.member.DeviceOsType;
-
 public record MemberRequest(
         String nickname,
         String deviceOsType


### PR DESCRIPTION
## 개요
- 추가 단어와 위치 값을 빈 문자열이 넘어오는 경우에도 정상적으로 시가 생성되는 버그를 수정했습니다.

## 작업사항
- 시 생성 시, 빈 문자열 예외처리
  - spring validation 의존성 추가
  - CardPoemRequest 내 location, address 값에 NotBlank annotation 추가

## 주의사항
- 위, 경도 값은 아무런 값을 넣지 않았을 때, 0으로 설정됩니다. 이에 대한 추가 논의가 필요할 것 같습니다.
